### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -206,8 +206,9 @@ func (s *Server) validateFrontendPath(requestPath, frontendDir string) (absDir, 
 		return "", "", false
 	}
 
-	// Validate that the requested path is within the frontend directory
-	if !strings.HasPrefix(absPath, absDir+string(filepath.Separator)) && absPath != absDir {
+	// Use filepath.Rel to validate that absPath is within absDir
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 		s.logger.Warn("Path traversal attempt detected", "requested_path", requestPath, "resolved_path", absPath)
 		return "", "", false
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/kuhlman-labs/GitHub-migrator/security/code-scanning/21](https://github.com/kuhlman-labs/GitHub-migrator/security/code-scanning/21)

To fully mitigate directory traversal issues, it's best to validate file access using `filepath.Rel` to check if the resolved path is inside the intended directory. This method handles edge cases better than reliance on `strings.HasPrefix`. Change the logic in the `validateFrontendPath` function to use `filepath.Rel` to ensure that the user-provided path resolves to a location inside the intended static directory. 

You should modify `validateFrontendPath` (lines 190–216) to:
- Resolve both `frontendDir` and the requested path to absolute paths.
- Call `filepath.Rel(absDir, absPath)` and check if the result starts with ".." or contains ".." as a component, meaning the path escapes the intended directory.

This change should happen in internal/api/server.go, lines 190–216. You do not need to add new imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
