### PR TITLE
Potential fix for code scanning alert no. 26: Uncontrolled data used in path expression

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -210,7 +210,8 @@ func (s *Server) validateFrontendPath(requestPath, frontendDir string) (absDir, 
 
 	// Security check: Ensure the resolved absolute path is within the frontend directory
 	// This prevents path traversal attacks by validating the final resolved path
-	if !strings.HasPrefix(absPath, absDir+string(filepath.Separator)) && absPath != absDir {
+	relPath, err := filepath.Rel(absDir, absPath)
+	if err != nil || strings.HasPrefix(relPath, "..") || filepath.IsAbs(relPath) {
 		s.logger.Warn("Path traversal attempt detected", "requested_path", requestPath, "resolved_path", absPath)
 		return "", "", false
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/kuhlman-labs/GitHub-migrator/security/code-scanning/26](https://github.com/kuhlman-labs/GitHub-migrator/security/code-scanning/26)

The best fix is to update the `validateFrontendPath` function to use `filepath.Rel` for traversal checks, which more accurately determines if the given path escapes the intended directory. The code should also disallow any requests that resolve to a path containing path segments outside the frontend directory. Optionally, you may want to defensively reject paths that resolve to symlinks outside the directory (though that would require more extensive changes). Below, the minimal change is to replace the `HasPrefix` check with a `filepath.Rel` check.

Specifically, edit the file internal/api/server.go:

- In `validateFrontendPath`, after resolving `absPath`, replace the prefix check with a `filepath.Rel` check. If `filepath.Rel(absDir, absPath)` starts with ".." or is absolute, the path escapes the directory and should be rejected.
- The rest of the code does not need to be changed, as `tryServeFile` relies entirely on the validity of `absPath`.
- No new imports are needed since `filepath.Rel` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces prefix-based check with a filepath.Rel-based validation to prevent path traversal when serving frontend files.
> 
> - **Security**:
>   - Strengthen `validateFrontendPath` in `internal/api/server.go` by replacing `strings.HasPrefix` absolute-path check with `filepath.Rel`-based validation (`..`/absolute detection) to block path traversal.
>   - Logs a warning and rejects requests when traversal is detected; downstream serving logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3948e735c89ed164e09cd7c99c0bcc5a96a0e26b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->