### PR TITLE
Implement ProjectsV2 loading and integration in discovery and profiling

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -706,3 +706,37 @@ func TestNewClientWithGHECAPISubdomain(t *testing.T) {
 		t.Error("GraphQL client is nil for GHEC data residency instance with api subdomain")
 	}
 }
+
+func TestListOrganizationProjects(t *testing.T) {
+	// This is a unit test to verify that the ListOrganizationProjects method
+	// is properly implemented and returns the expected structure.
+	// Note: This requires a real GitHub connection for integration testing.
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Test that the method exists and can be called
+	// For a real test, you would need valid credentials
+	cfg := ClientConfig{
+		BaseURL:     "https://api.github.com",
+		Token:       "test-token",
+		Timeout:     30 * time.Second,
+		RetryConfig: DefaultRetryConfig(),
+		Logger:      logger,
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v, want nil", err)
+	}
+
+	// Verify the method exists and returns a non-nil map
+	// (even if empty due to no real credentials)
+	ctx := context.Background()
+	projectsMap, _ := client.ListOrganizationProjects(ctx, "test-org")
+
+	// We expect an error or an empty map since we're using test credentials
+	// The important thing is the method is callable and returns the right type
+	if projectsMap == nil {
+		t.Error("ListOrganizationProjects returned nil map, expected non-nil even on error")
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -155,6 +155,7 @@ type ComplexityBreakdown struct {
 	LFSPoints                int `json:"lfs_points"`                 // 2 points if has LFS
 	SubmodulesPoints         int `json:"submodules_points"`          // 2 points if has submodules
 	AppsPoints               int `json:"apps_points"`                // 2 points if has installed apps
+	ProjectsPoints           int `json:"projects_points"`            // 2 points if has ProjectsV2
 	SecurityPoints           int `json:"security_points"`            // 1 point if has GHAS features
 	WebhooksPoints           int `json:"webhooks_points"`            // 1 point if has webhooks
 	TagProtectionsPoints     int `json:"tag_protections_points"`     // 1 point if has tag protections

--- a/web/src/components/BatchManagement/RepositoryListItem.tsx
+++ b/web/src/components/BatchManagement/RepositoryListItem.tsx
@@ -44,6 +44,7 @@ export function RepositoryListItem({ repository, selected, onToggle }: Repositor
     if (repository.has_lfs) score += 2;
     if (repository.has_submodules) score += 2;
     if (repository.installed_apps_count > 0) score += 2;
+    if (repository.has_projects) score += 2;
     
     // Low impact features (1 point each)
     if (repository.has_code_scanning || repository.has_dependabot || repository.has_secret_scanning) score += 1;

--- a/web/src/components/RepositoryDetail/index.tsx
+++ b/web/src/components/RepositoryDetail/index.tsx
@@ -664,7 +664,7 @@ export function RepositoryDetail() {
                   
                   // If backend provides breakdown, use it; otherwise calculate
                   let sizePoints, largeFilesPoints, environmentsPoints, secretsPoints, packagesPoints, runnersPoints;
-                  let variablesPoints, discussionsPoints, releasesPoints, lfsPoints, submodulesPoints, appsPoints;
+                  let variablesPoints, discussionsPoints, releasesPoints, lfsPoints, submodulesPoints, appsPoints, projectsPoints;
                   let securityPoints, webhooksPoints, tagProtectionsPoints, branchProtectionsPoints, rulesetsPoints;
                   let publicVisibilityPoints, internalVisibilityPoints, codeownersPoints, activityPoints;
                   
@@ -682,6 +682,7 @@ export function RepositoryDetail() {
                     lfsPoints = breakdown.lfs_points;
                     submodulesPoints = breakdown.submodules_points;
                     appsPoints = breakdown.apps_points;
+                    projectsPoints = breakdown.projects_points;
                     securityPoints = breakdown.security_points;
                     webhooksPoints = breakdown.webhooks_points;
                     tagProtectionsPoints = breakdown.tag_protections_points;
@@ -714,6 +715,7 @@ export function RepositoryDetail() {
                     lfsPoints = repository.has_lfs ? 2 : 0;
                     submodulesPoints = repository.has_submodules ? 2 : 0;
                     appsPoints = repository.installed_apps_count > 0 ? 2 : 0;
+                    projectsPoints = repository.has_projects ? 2 : 0;
                     securityPoints = (repository.has_code_scanning || repository.has_dependabot || repository.has_secret_scanning) ? 1 : 0;
                     webhooksPoints = repository.webhook_count > 0 ? 1 : 0;
                     tagProtectionsPoints = repository.tag_protection_count > 0 ? 1 : 0;
@@ -735,7 +737,7 @@ export function RepositoryDetail() {
                   // Use backend score when available, otherwise calculate from components
                   const totalPoints = repository.complexity_score ?? (
                     sizePoints + largeFilesPoints + environmentsPoints + secretsPoints + packagesPoints + runnersPoints +
-                    variablesPoints + discussionsPoints + releasesPoints + lfsPoints + submodulesPoints + securityPoints + appsPoints +
+                    variablesPoints + discussionsPoints + releasesPoints + lfsPoints + submodulesPoints + securityPoints + appsPoints + projectsPoints +
                     webhooksPoints + tagProtectionsPoints + branchProtectionsPoints + rulesetsPoints + publicVisibilityPoints + internalVisibilityPoints + codeownersPoints +
                     activityPoints
                   );
@@ -944,6 +946,16 @@ export function RepositoryDetail() {
                           </div>
                           <span className={`text-lg font-semibold ${appsPoints > 0 ? 'text-orange-600' : 'text-gray-400'}`}>
                             +{appsPoints}
+                          </span>
+                        </div>
+                        
+                        <div className="flex justify-between items-center py-2 border-b border-gray-200">
+                          <div>
+                            <div className="text-sm font-medium text-gray-900">ProjectsV2</div>
+                            <div className="text-xs text-gray-500">{repository.has_projects ? 'Yes (don\'t migrate, manual recreation required)' : 'No'}</div>
+                          </div>
+                          <span className={`text-lg font-semibold ${projectsPoints > 0 ? 'text-orange-600' : 'text-gray-400'}`}>
+                            +{projectsPoints}
                           </span>
                         </div>
                         

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -105,6 +105,7 @@ export interface ComplexityBreakdown {
   lfs_points: number;
   submodules_points: number;
   apps_points: number;
+  projects_points: number;
   security_points: number;
   webhooks_points: number;
   tag_protections_points: number;


### PR DESCRIPTION
- Added functionality to load ProjectsV2 maps for organizations in the Collector and Profiler, enhancing repository discovery capabilities.
- Updated the Profiler to utilize the loaded ProjectsV2 data for determining project associations in repositories.
- Introduced new methods in the GitHub client to fetch organization-level ProjectsV2 using GraphQL.
- Enhanced complexity scoring to include ProjectsV2, reflecting its impact on repository management.
- Updated UI components to display ProjectsV2 information and associated scoring in repository details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Loads org-level ProjectsV2 and uses it to detect per-repo projects, adds it to complexity scoring, and surfaces it in the UI.
> 
> - **Discovery/Profiling**:
>   - Load org-level ProjectsV2 map via `Profiler.LoadProjectsMap` and use it in `Collector` flows (single-org, enterprise, parallel workers).
>   - Replace classic projects check with ProjectsV2-based `profileProjectContent` using cached `projectsMap`.
> - **GitHub Client**:
>   - Add GraphQL methods `ListOrganizationProjects` and `paginateProjectRepositories` to build repo→ProjectsV2 map (with pagination and retries).
> - **Scoring/Models/Storage**:
>   - Add `projects_points` to `models.ComplexityBreakdown` and SQL builders; include `has_projects` (+2) in total complexity score and breakdown queries.
> - **UI**:
>   - Show ProjectsV2 in Repository Detail (points and status) and include in frontend score; add handling in `RepositoryListItem` and types.
> - **Tests**:
>   - Add unit test stub for `ListOrganizationProjects` in `client_test.go`.
> - **Misc**:
>   - Add `//nolint:gocyclo` in enterprise discovery; minor logging additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0caee1ab0c5e4be987f27e56745c5d522af8fb66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->