### PR TITLE
Add GitHub team support for repository filtering and discovery

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -201,6 +201,9 @@ func (s *Server) Router() http.Handler {
 	protect("GET /api/v1/organizations/list", s.handler.GetOrganizationList)
 	protect("GET /api/v1/projects", s.handler.ListProjects)
 
+	// Team endpoints (GitHub only)
+	protect("GET /api/v1/teams", s.handler.ListTeams)
+
 	// Dashboard endpoints
 	protect("GET /api/v1/dashboard/action-items", s.handler.GetDashboardActionItems)
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -441,3 +441,40 @@ const (
 	DependencyTypeDependencyGraph = "dependency_graph"
 	DependencyTypePackage         = "package"
 )
+
+// GitHubTeam represents a GitHub team for filtering repositories by team membership
+// Teams are org-scoped, so the same team name can exist in different organizations
+type GitHubTeam struct {
+	ID           int64     `json:"id" db:"id" gorm:"primaryKey;autoIncrement"`
+	Organization string    `json:"organization" db:"organization" gorm:"column:organization;not null;uniqueIndex:idx_github_teams_org_slug"`
+	Slug         string    `json:"slug" db:"slug" gorm:"column:slug;not null;uniqueIndex:idx_github_teams_org_slug"`
+	Name         string    `json:"name" db:"name" gorm:"column:name;not null"`
+	Description  *string   `json:"description,omitempty" db:"description" gorm:"column:description;type:text"`
+	Privacy      string    `json:"privacy" db:"privacy" gorm:"column:privacy;not null;default:closed"`
+	DiscoveredAt time.Time `json:"discovered_at" db:"discovered_at" gorm:"column:discovered_at;not null;autoCreateTime"`
+	UpdatedAt    time.Time `json:"updated_at" db:"updated_at" gorm:"column:updated_at;not null;autoUpdateTime"`
+}
+
+// TableName specifies the table name for GitHubTeam model
+func (GitHubTeam) TableName() string {
+	return "github_teams"
+}
+
+// FullSlug returns the unique identifier for the team in "org/team-slug" format
+func (t *GitHubTeam) FullSlug() string {
+	return t.Organization + "/" + t.Slug
+}
+
+// GitHubTeamRepository represents the many-to-many relationship between teams and repositories
+type GitHubTeamRepository struct {
+	ID           int64     `json:"id" db:"id" gorm:"primaryKey;autoIncrement"`
+	TeamID       int64     `json:"team_id" db:"team_id" gorm:"column:team_id;not null;uniqueIndex:idx_github_team_repo"`
+	RepositoryID int64     `json:"repository_id" db:"repository_id" gorm:"column:repository_id;not null;uniqueIndex:idx_github_team_repo;index"`
+	Permission   string    `json:"permission" db:"permission" gorm:"column:permission;not null;default:pull"` // pull, push, admin, maintain, triage
+	DiscoveredAt time.Time `json:"discovered_at" db:"discovered_at" gorm:"column:discovered_at;not null;autoCreateTime"`
+}
+
+// TableName specifies the table name for GitHubTeamRepository model
+func (GitHubTeamRepository) TableName() string {
+	return "github_team_repositories"
+}

--- a/internal/storage/migrations/postgres/026_add_github_teams.sql
+++ b/internal/storage/migrations/postgres/026_add_github_teams.sql
@@ -1,0 +1,49 @@
+-- Create github_teams table to store GitHub team information
+-- Teams are org-scoped, so the same team name can exist in different organizations
+
+-- +goose Up
+CREATE TABLE IF NOT EXISTS github_teams (
+    id BIGSERIAL PRIMARY KEY,
+    organization TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    privacy TEXT NOT NULL DEFAULT 'closed',
+    discovered_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    
+    UNIQUE(organization, slug)
+);
+
+-- Create junction table for team-repository relationships
+CREATE TABLE IF NOT EXISTS github_team_repositories (
+    id BIGSERIAL PRIMARY KEY,
+    team_id BIGINT NOT NULL,
+    repository_id BIGINT NOT NULL,
+    permission TEXT NOT NULL DEFAULT 'pull',
+    discovered_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    
+    FOREIGN KEY (team_id) REFERENCES github_teams(id) ON DELETE CASCADE,
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE,
+    UNIQUE(team_id, repository_id)
+);
+
+-- Index for finding teams by organization
+CREATE INDEX IF NOT EXISTS idx_github_teams_organization 
+    ON github_teams(organization);
+
+-- Index for finding all team memberships for a repository
+CREATE INDEX IF NOT EXISTS idx_github_team_repositories_repo_id 
+    ON github_team_repositories(repository_id);
+
+-- Index for finding all repositories in a team
+CREATE INDEX IF NOT EXISTS idx_github_team_repositories_team_id 
+    ON github_team_repositories(team_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_github_team_repositories_team_id;
+DROP INDEX IF EXISTS idx_github_team_repositories_repo_id;
+DROP INDEX IF EXISTS idx_github_teams_organization;
+DROP TABLE IF EXISTS github_team_repositories;
+DROP TABLE IF EXISTS github_teams;
+

--- a/internal/storage/migrations/sqlite/026_add_github_teams.sql
+++ b/internal/storage/migrations/sqlite/026_add_github_teams.sql
@@ -1,0 +1,49 @@
+-- Create github_teams table to store GitHub team information
+-- Teams are org-scoped, so the same team name can exist in different organizations
+
+-- +goose Up
+CREATE TABLE IF NOT EXISTS github_teams (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    organization TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    privacy TEXT NOT NULL DEFAULT 'closed',
+    discovered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    UNIQUE(organization, slug)
+);
+
+-- Create junction table for team-repository relationships
+CREATE TABLE IF NOT EXISTS github_team_repositories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id INTEGER NOT NULL,
+    repository_id INTEGER NOT NULL,
+    permission TEXT NOT NULL DEFAULT 'pull',
+    discovered_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    
+    FOREIGN KEY (team_id) REFERENCES github_teams(id) ON DELETE CASCADE,
+    FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE,
+    UNIQUE(team_id, repository_id)
+);
+
+-- Index for finding teams by organization
+CREATE INDEX IF NOT EXISTS idx_github_teams_organization 
+    ON github_teams(organization);
+
+-- Index for finding all team memberships for a repository
+CREATE INDEX IF NOT EXISTS idx_github_team_repositories_repo_id 
+    ON github_team_repositories(repository_id);
+
+-- Index for finding all repositories in a team
+CREATE INDEX IF NOT EXISTS idx_github_team_repositories_team_id 
+    ON github_team_repositories(team_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_github_team_repositories_team_id;
+DROP INDEX IF EXISTS idx_github_team_repositories_repo_id;
+DROP INDEX IF EXISTS idx_github_teams_organization;
+DROP TABLE IF EXISTS github_team_repositories;
+DROP TABLE IF EXISTS github_teams;
+

--- a/internal/storage/migrations/sqlserver/026_add_github_teams.sql
+++ b/internal/storage/migrations/sqlserver/026_add_github_teams.sql
@@ -1,0 +1,70 @@
+-- Create github_teams table to store GitHub team information
+-- Teams are org-scoped, so the same team name can exist in different organizations
+
+-- +goose Up
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'github_teams')
+BEGIN
+    CREATE TABLE github_teams (
+        id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        organization NVARCHAR(255) NOT NULL,
+        slug NVARCHAR(255) NOT NULL,
+        name NVARCHAR(255) NOT NULL,
+        description NVARCHAR(MAX),
+        privacy NVARCHAR(50) NOT NULL DEFAULT 'closed',
+        discovered_at DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+        updated_at DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+        
+        CONSTRAINT UQ_github_teams_org_slug UNIQUE(organization, slug)
+    );
+END;
+
+-- Create junction table for team-repository relationships
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'github_team_repositories')
+BEGIN
+    CREATE TABLE github_team_repositories (
+        id BIGINT IDENTITY(1,1) PRIMARY KEY,
+        team_id BIGINT NOT NULL,
+        repository_id BIGINT NOT NULL,
+        permission NVARCHAR(50) NOT NULL DEFAULT 'pull',
+        discovered_at DATETIME2 NOT NULL DEFAULT GETUTCDATE(),
+        
+        CONSTRAINT FK_github_team_repositories_team FOREIGN KEY (team_id) REFERENCES github_teams(id) ON DELETE CASCADE,
+        CONSTRAINT FK_github_team_repositories_repo FOREIGN KEY (repository_id) REFERENCES repositories(id) ON DELETE CASCADE,
+        CONSTRAINT UQ_github_team_repositories UNIQUE(team_id, repository_id)
+    );
+END;
+
+-- Index for finding teams by organization
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_teams_organization')
+BEGIN
+    CREATE INDEX idx_github_teams_organization ON github_teams(organization);
+END;
+
+-- Index for finding all team memberships for a repository
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_team_repositories_repo_id')
+BEGIN
+    CREATE INDEX idx_github_team_repositories_repo_id ON github_team_repositories(repository_id);
+END;
+
+-- Index for finding all repositories in a team
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_team_repositories_team_id')
+BEGIN
+    CREATE INDEX idx_github_team_repositories_team_id ON github_team_repositories(team_id);
+END;
+
+-- +goose Down
+IF EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_team_repositories_team_id')
+    DROP INDEX idx_github_team_repositories_team_id ON github_team_repositories;
+
+IF EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_team_repositories_repo_id')
+    DROP INDEX idx_github_team_repositories_repo_id ON github_team_repositories;
+
+IF EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_github_teams_organization')
+    DROP INDEX idx_github_teams_organization ON github_teams;
+
+IF EXISTS (SELECT * FROM sys.tables WHERE name = 'github_team_repositories')
+    DROP TABLE github_team_repositories;
+
+IF EXISTS (SELECT * FROM sys.tables WHERE name = 'github_teams')
+    DROP TABLE github_teams;
+

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -457,6 +457,11 @@ func (d *Database) applyListScopes(query *gorm.DB, filters map[string]interface{
 		query = query.Scopes(WithAvailableForBatch())
 	}
 
+	// Apply team filter
+	if team, ok := filters["team"]; ok {
+		query = query.Scopes(WithTeam(team))
+	}
+
 	// Apply ordering
 	sortBy := "name" // default
 	if sort, ok := filters["sort_by"].(string); ok {

--- a/internal/storage/repository_teams.go
+++ b/internal/storage/repository_teams.go
@@ -1,0 +1,193 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kuhlman-labs/github-migrator/internal/models"
+	"gorm.io/gorm"
+)
+
+// SaveTeam inserts or updates a GitHub team in the database
+func (d *Database) SaveTeam(ctx context.Context, team *models.GitHubTeam) error {
+	// Check if team already exists
+	var existing models.GitHubTeam
+	err := d.db.WithContext(ctx).
+		Where("organization = ? AND slug = ?", team.Organization, team.Slug).
+		First(&existing).Error
+
+	if err == gorm.ErrRecordNotFound {
+		// Insert new team
+		if team.DiscoveredAt.IsZero() {
+			team.DiscoveredAt = time.Now()
+		}
+		if team.UpdatedAt.IsZero() {
+			team.UpdatedAt = time.Now()
+		}
+
+		result := d.db.WithContext(ctx).Create(team)
+		if result.Error != nil {
+			return fmt.Errorf("failed to create team: %w", result.Error)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check existing team: %w", err)
+	}
+
+	// Team exists - update it
+	team.ID = existing.ID
+	team.DiscoveredAt = existing.DiscoveredAt
+	team.UpdatedAt = time.Now()
+
+	result := d.db.WithContext(ctx).Model(&existing).Updates(map[string]interface{}{
+		"name":        team.Name,
+		"description": team.Description,
+		"privacy":     team.Privacy,
+		"updated_at":  team.UpdatedAt,
+	})
+
+	if result.Error != nil {
+		return fmt.Errorf("failed to update team: %w", result.Error)
+	}
+
+	return nil
+}
+
+// SaveTeamRepository creates or updates a team-repository association
+// repoFullName should be in "org/repo" format
+func (d *Database) SaveTeamRepository(ctx context.Context, teamID int64, repoFullName, permission string) error {
+	// First, find the repository by full name
+	var repo models.Repository
+	err := d.db.WithContext(ctx).
+		Where("full_name = ?", repoFullName).
+		First(&repo).Error
+
+	if err == gorm.ErrRecordNotFound {
+		// Repository not found in our database - skip it
+		// This can happen if the team has access to repos we haven't discovered
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to find repository: %w", err)
+	}
+
+	// Check if association already exists
+	var existing models.GitHubTeamRepository
+	err = d.db.WithContext(ctx).
+		Where("team_id = ? AND repository_id = ?", teamID, repo.ID).
+		First(&existing).Error
+
+	if err == gorm.ErrRecordNotFound {
+		// Create new association
+		association := &models.GitHubTeamRepository{
+			TeamID:       teamID,
+			RepositoryID: repo.ID,
+			Permission:   permission,
+			DiscoveredAt: time.Now(),
+		}
+
+		result := d.db.WithContext(ctx).Create(association)
+		if result.Error != nil {
+			return fmt.Errorf("failed to create team-repository association: %w", result.Error)
+		}
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to check existing association: %w", err)
+	}
+
+	// Association exists - update permission if changed
+	if existing.Permission != permission {
+		result := d.db.WithContext(ctx).Model(&existing).Update("permission", permission)
+		if result.Error != nil {
+			return fmt.Errorf("failed to update team-repository association: %w", result.Error)
+		}
+	}
+
+	return nil
+}
+
+// ListTeams returns all teams with optional organization filter
+func (d *Database) ListTeams(ctx context.Context, orgFilter string) ([]*models.GitHubTeam, error) {
+	var teams []*models.GitHubTeam
+	query := d.db.WithContext(ctx)
+
+	if orgFilter != "" {
+		// Support comma-separated organization list
+		if strings.Contains(orgFilter, ",") {
+			orgs := strings.Split(orgFilter, ",")
+			trimmedOrgs := make([]string, len(orgs))
+			for i, org := range orgs {
+				trimmedOrgs[i] = strings.TrimSpace(org)
+			}
+			query = query.Where("organization IN ?", trimmedOrgs)
+		} else {
+			query = query.Where("organization = ?", orgFilter)
+		}
+	}
+
+	err := query.Order("organization ASC, name ASC").Find(&teams).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list teams: %w", err)
+	}
+
+	return teams, nil
+}
+
+// GetTeamByOrgAndSlug retrieves a team by organization and slug
+func (d *Database) GetTeamByOrgAndSlug(ctx context.Context, org, slug string) (*models.GitHubTeam, error) {
+	var team models.GitHubTeam
+	err := d.db.WithContext(ctx).
+		Where("organization = ? AND slug = ?", org, slug).
+		First(&team).Error
+
+	if err == gorm.ErrRecordNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get team: %w", err)
+	}
+
+	return &team, nil
+}
+
+// GetTeamsForRepository returns all teams that have access to a repository
+func (d *Database) GetTeamsForRepository(ctx context.Context, repoID int64) ([]*models.GitHubTeam, error) {
+	var teams []*models.GitHubTeam
+	err := d.db.WithContext(ctx).
+		Joins("JOIN github_team_repositories gtr ON gtr.team_id = github_teams.id").
+		Where("gtr.repository_id = ?", repoID).
+		Order("organization ASC, name ASC").
+		Find(&teams).Error
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get teams for repository: %w", err)
+	}
+
+	return teams, nil
+}
+
+// DeleteTeamsForOrganization removes all teams and their repository associations for an organization
+// This is useful when re-running discovery for an organization
+func (d *Database) DeleteTeamsForOrganization(ctx context.Context, org string) error {
+	// Use transaction to ensure atomicity
+	return d.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// First, delete all team-repository associations for teams in this org
+		// (using subquery to find team IDs)
+		result := tx.Exec(`
+			DELETE FROM github_team_repositories 
+			WHERE team_id IN (SELECT id FROM github_teams WHERE organization = ?)
+		`, org)
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete team-repository associations: %w", result.Error)
+		}
+
+		// Then delete the teams themselves
+		result = tx.Where("organization = ?", org).Delete(&models.GitHubTeam{})
+		if result.Error != nil {
+			return fmt.Errorf("failed to delete teams: %w", result.Error)
+		}
+
+		return nil
+	})
+}

--- a/web/src/components/BatchManagement/OrganizationSelector.tsx
+++ b/web/src/components/BatchManagement/OrganizationSelector.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDownIcon } from '@primer/octicons-react';
 
 interface OrganizationSelectorProps {
@@ -9,6 +10,8 @@ interface OrganizationSelectorProps {
   placeholder?: string;
   searchPlaceholder?: string;
   emptyMessage?: string;
+  renderLabel?: (value: string) => string;
+  useFixedPosition?: boolean;
 }
 
 export function OrganizationSelector({
@@ -19,22 +22,75 @@ export function OrganizationSelector({
   placeholder = 'All Organizations',
   searchPlaceholder = 'Search organizations...',
   emptyMessage = 'No organizations found',
+  renderLabel,
+  useFixedPosition = false,
 }: OrganizationSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0, width: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = useCallback(() => {
+    if (buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setDropdownPosition({
+        top: rect.bottom + 4,
+        left: rect.left,
+        width: rect.width,
+      });
+    }
+  }, []); // No dependencies - function reference stays stable
+
+  useEffect(() => {
+    if (isOpen) {
+      updatePosition();
+      window.addEventListener('scroll', updatePosition, true);
+      window.addEventListener('resize', updatePosition);
+      return () => {
+        window.removeEventListener('scroll', updatePosition, true);
+        window.removeEventListener('resize', updatePosition);
+      };
+    }
+  }, [isOpen, updatePosition]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+      const target = event.target as HTMLElement;
+      
+      // Check if click is inside button
+      if (buttonRef.current?.contains(target)) {
+        return;
       }
+      
+      // Check if click is inside dropdown (works with portal)
+      // When using portal, dropdownRef.current is in document.body
+      if (dropdownRef.current?.contains(target)) {
+        return;
+      }
+      
+      // Also check by traversing up from target to see if we're in the dropdown
+      let element: HTMLElement | null = target;
+      while (element) {
+        if (element === dropdownRef.current) {
+          return;
+        }
+        element = element.parentElement;
+      }
+      
+      setIsOpen(false);
     };
 
     if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
+      // Use setTimeout to avoid the click that opened the dropdown from closing it
+      const timer = setTimeout(() => {
+        document.addEventListener('mousedown', handleClickOutside);
+      }, 10);
+      return () => {
+        clearTimeout(timer);
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
     }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isOpen]);
 
   const filteredOrgs = organizations.filter((org) =>
@@ -42,11 +98,10 @@ export function OrganizationSelector({
   );
 
   const handleToggle = (org: string) => {
-    if (selectedOrganizations.includes(org)) {
-      onChange(selectedOrganizations.filter((o) => o !== org));
-    } else {
-      onChange([...selectedOrganizations, org]);
-    }
+    const newSelection = selectedOrganizations.includes(org)
+      ? selectedOrganizations.filter((o) => o !== org)
+      : [...selectedOrganizations, org];
+    onChange(newSelection);
   };
 
   const handleSelectAll = () => {
@@ -57,9 +112,97 @@ export function OrganizationSelector({
     onChange([]);
   };
 
+  const dropdownContent = (
+    <div 
+      ref={dropdownRef}
+      onMouseDown={(e) => e.stopPropagation()}
+      style={{
+        position: useFixedPosition ? 'fixed' : 'absolute',
+        top: useFixedPosition ? dropdownPosition.top : '100%',
+        left: useFixedPosition ? dropdownPosition.left : 0,
+        width: useFixedPosition ? dropdownPosition.width : '100%',
+        marginTop: useFixedPosition ? 0 : 4,
+        zIndex: 99999,
+        backgroundColor: 'var(--bgColor-default)',
+        border: '1px solid var(--borderColor-default)',
+        borderRadius: '0.5rem',
+        boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2)',
+      }}
+    >
+      <div className="p-2" style={{ borderBottom: '1px solid var(--borderColor-default)' }}>
+        <input
+          type="text"
+          placeholder={searchPlaceholder}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="w-full px-3 py-2 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+          style={{
+            border: '1px solid var(--borderColor-default)',
+            backgroundColor: 'var(--control-bgColor-rest)',
+            color: 'var(--fgColor-default)'
+          }}
+        />
+      </div>
+
+      <div className="max-h-64 overflow-y-auto">
+        {loading ? (
+          <div className="p-4 text-center text-sm" style={{ color: 'var(--fgColor-muted)' }}>Loading...</div>
+        ) : filteredOrgs.length === 0 ? (
+          <div className="p-4 text-center text-sm" style={{ color: 'var(--fgColor-muted)' }}>{emptyMessage}</div>
+        ) : (
+          <>
+            <div className="flex gap-2 p-2" style={{ borderBottom: '1px solid var(--borderColor-muted)' }}>
+              <button
+                type="button"
+                onClick={() => handleSelectAll()}
+                className="flex-1 px-2 py-1 text-xs rounded transition-opacity hover:opacity-80"
+                style={{ color: 'var(--fgColor-accent)' }}
+              >
+                Select All
+              </button>
+              {selectedOrganizations.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => handleClearAll()}
+                  className="flex-1 px-2 py-1 text-xs rounded transition-opacity hover:opacity-80"
+                  style={{ color: 'var(--fgColor-default)' }}
+                >
+                  Clear All
+                </button>
+              )}
+            </div>
+            <div className="p-1">
+              {filteredOrgs.map((org) => (
+                <div
+                  key={org}
+                  className="flex items-center gap-2 px-3 py-2 rounded cursor-pointer hover:bg-gray-700"
+                  onClick={() => handleToggle(org)}
+                  role="option"
+                  aria-selected={selectedOrganizations.includes(org)}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selectedOrganizations.includes(org)}
+                    onChange={() => handleToggle(org)}
+                    className="rounded text-blue-600 focus:ring-blue-500"
+                    style={{ borderColor: 'var(--borderColor-default)' }}
+                  />
+                  <span className="text-sm" style={{ color: 'var(--fgColor-default)' }}>
+                    {renderLabel ? renderLabel(org) : org}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative">
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="w-full px-3 py-2 text-left rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition-opacity hover:opacity-80"
@@ -76,86 +219,19 @@ export function OrganizationSelector({
               : `${selectedOrganizations.length} selected`}
           </span>
           <span style={{ color: 'var(--fgColor-muted)' }}>
-          <ChevronDownIcon
+            <ChevronDownIcon
               className={`transition-transform ${isOpen ? 'rotate-180' : ''}`}
-            size={16}
-          />
+              size={16}
+            />
           </span>
         </div>
       </button>
 
       {isOpen && (
-        <div 
-          className="absolute z-50 mt-1 w-full rounded-lg shadow-lg"
-          style={{
-            backgroundColor: 'var(--bgColor-default)',
-            border: '1px solid var(--borderColor-default)'
-          }}
-        >
-          <div className="p-2" style={{ borderBottom: '1px solid var(--borderColor-default)' }}>
-            <input
-              type="text"
-              placeholder={searchPlaceholder}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full px-3 py-2 text-sm rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
-              style={{
-                border: '1px solid var(--borderColor-default)',
-                backgroundColor: 'var(--control-bgColor-rest)',
-                color: 'var(--fgColor-default)'
-              }}
-              onClick={(e) => e.stopPropagation()}
-            />
-          </div>
-
-          <div className="max-h-64 overflow-y-auto">
-            {loading ? (
-              <div className="p-4 text-center text-sm" style={{ color: 'var(--fgColor-muted)' }}>Loading...</div>
-            ) : filteredOrgs.length === 0 ? (
-              <div className="p-4 text-center text-sm" style={{ color: 'var(--fgColor-muted)' }}>{emptyMessage}</div>
-            ) : (
-              <>
-                <div className="flex gap-2 p-2" style={{ borderBottom: '1px solid var(--borderColor-muted)' }}>
-                  <button
-                    onClick={handleSelectAll}
-                    className="flex-1 px-2 py-1 text-xs rounded transition-opacity hover:opacity-80"
-                    style={{ color: 'var(--fgColor-accent)' }}
-                  >
-                    Select All
-                  </button>
-                  {selectedOrganizations.length > 0 && (
-                    <button
-                      onClick={handleClearAll}
-                      className="flex-1 px-2 py-1 text-xs rounded transition-opacity hover:opacity-80"
-                      style={{ color: 'var(--fgColor-default)' }}
-                    >
-                      Clear All
-                    </button>
-                  )}
-                </div>
-                <div className="p-1">
-                  {filteredOrgs.map((org) => (
-                    <label
-                      key={org}
-                      className="flex items-center gap-2 px-3 py-2 rounded cursor-pointer transition-opacity hover:opacity-80"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedOrganizations.includes(org)}
-                        onChange={() => handleToggle(org)}
-                        className="rounded text-blue-600 focus:ring-blue-500"
-                        style={{ borderColor: 'var(--borderColor-default)' }}
-                      />
-                      <span className="text-sm" style={{ color: 'var(--fgColor-default)' }}>{org}</span>
-                    </label>
-                  ))}
-                </div>
-              </>
-            )}
-          </div>
-        </div>
+        useFixedPosition 
+          ? createPortal(dropdownContent, document.body)
+          : dropdownContent
       )}
     </div>
   );
 }
-

--- a/web/src/components/Repositories/index.tsx
+++ b/web/src/components/Repositories/index.tsx
@@ -89,6 +89,7 @@ export function Repositories() {
     if (urlFilters.organization) count++;
     if (urlFilters.ado_organization) count++;
     if (urlFilters.project) count++;
+    if (urlFilters.team) count++;
     if (urlFilters.search) count++;
     if (urlFilters.complexity) count++;
     if (urlFilters.size_category) count++;
@@ -216,8 +217,11 @@ export function Repositories() {
                 {/* Title and Info */}
                 <div>
                   <h1 className="text-2xl font-semibold" style={{ color: 'var(--fgColor-default)' }}>
-                    {urlFilters.project ? (
-                      // Project filter takes precedence (more specific than org)
+                    {urlFilters.team ? (
+                      // Team filter takes precedence (most specific)
+                      <>Repositories in Team <span style={{ color: 'var(--fgColor-accent)' }}>{formatFilterValue(urlFilters.team)}</span></>
+                    ) : urlFilters.project ? (
+                      // Project filter (more specific than org)
                       <>Repositories in Project <span style={{ color: 'var(--fgColor-accent)' }}>{formatFilterValue(urlFilters.project)}</span></>
                     ) : urlFilters.ado_organization ? (
                       <>Repositories in Organization <span style={{ color: 'var(--fgColor-accent)' }}>{formatFilterValue(urlFilters.ado_organization)}</span></>

--- a/web/src/components/common/UnifiedFilterSidebar.tsx
+++ b/web/src/components/common/UnifiedFilterSidebar.tsx
@@ -177,7 +177,7 @@ export function UnifiedFilterSidebar({
         for (const org of selectedOrgs) {
           try {
             const orgTeams = await api.listTeams(org);
-            orgTeams.forEach((team: GitHubTeam) => {
+            (orgTeams || []).forEach((team: GitHubTeam) => {
               if (!seenTeams.has(team.full_slug)) {
                 seenTeams.add(team.full_slug);
                 allTeams.push(team);

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -8,6 +8,7 @@ import type {
   MigrationLogsResponse,
   Organization,
   Project,
+  GitHubTeam,
   MigrationHistoryEntry,
   RepositoryFilters,
   RepositoryListResponse,
@@ -92,6 +93,10 @@ export const api = {
     
     if (filters?.project && Array.isArray(filters.project)) {
       params.project = filters.project.join(',');
+    }
+    
+    if (filters?.team && Array.isArray(filters.team)) {
+      params.team = filters.team.join(',');
     }
     
     if (filters?.complexity && Array.isArray(filters.complexity)) {
@@ -181,6 +186,12 @@ export const api = {
 
   async getOrganizationList(): Promise<string[]> {
     const { data } = await client.get('/organizations/list');
+    return data;
+  },
+
+  // Teams (GitHub only)
+  async listTeams(organization?: string): Promise<GitHubTeam[]> {
+    const { data } = await client.get('/teams', { params: { organization } });
     return data;
   },
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -265,6 +265,17 @@ export interface Project {
   status_counts: Record<string, number>;
 }
 
+// GitHub Team type - teams are org-scoped
+export interface GitHubTeam {
+  id: number;
+  organization: string;
+  slug: string;
+  name: string;
+  description?: string;
+  privacy: string;
+  full_slug: string; // "org/team-slug" format for unique identification
+}
+
 // Azure DevOps Project type
 export interface ADOProject {
   id: string;
@@ -507,6 +518,7 @@ export interface RepositoryFilters {
   organization?: string | string[];
   ado_organization?: string | string[]; // For Azure DevOps organizations (filters by ado_projects table)
   project?: string | string[]; // For Azure DevOps projects
+  team?: string | string[]; // For GitHub teams (format: "org/team-slug")
   min_size?: number;
   max_size?: number;
   

--- a/web/src/utils/filters.ts
+++ b/web/src/utils/filters.ts
@@ -44,6 +44,15 @@ export function filtersToSearchParams(filters: RepositoryFilters): URLSearchPara
     }
   }
 
+  // Handle team (can be string or array) - GitHub teams in "org/team-slug" format
+  if (filters.team) {
+    if (Array.isArray(filters.team)) {
+      params.set('team', filters.team.join(','));
+    } else {
+      params.set('team', filters.team);
+    }
+  }
+
   // Handle size filters
   if (filters.min_size !== undefined) params.set('min_size', filters.min_size.toString());
   if (filters.max_size !== undefined) params.set('max_size', filters.max_size.toString());
@@ -275,6 +284,12 @@ export function searchParamsToFilters(searchParams: URLSearchParams): Repository
   const project = searchParams.get('project');
   if (project) {
     filters.project = project.includes(',') ? project.split(',') : project;
+  }
+
+  // Team filter (GitHub teams in "org/team-slug" format)
+  const team = searchParams.get('team');
+  if (team) {
+    filters.team = team.includes(',') ? team.split(',') : team;
   }
 
   const complexity = searchParams.get('complexity');


### PR DESCRIPTION
- Introduced new API endpoints for listing GitHub teams and their associated repositories.
- Updated the database schema to include tables for GitHub teams and team-repository associations.
- Enhanced the repository filtering logic to support filtering by GitHub teams using the "org/team-slug" format.
- Modified frontend components to allow selection and display of teams in the filtering UI.
- Implemented backend logic for discovering teams during repository discovery processes.
- Improved overall documentation to reflect new features and usage instructions for team filtering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end GitHub team support: discovery + persistence, `/api/v1/teams` endpoint, repo filtering by `team=org/team-slug`, and UI filters with team selection.
> 
> - **Backend/API**:
>   - Add `GET /api/v1/teams` (GitHub only) with optional `organization` filter and `full_slug` in response.
>   - Extend `GET /api/v1/repositories` to accept `team` (comma-separated `org/team-slug`) and wire to storage scope.
>   - Register new route in `internal/api/server.go`.
> - **Discovery**:
>   - Discover org teams and their repositories; persist teams and team-repo permissions during org/enterprise discovery.
> - **Storage/DB**:
>   - New models: `GitHubTeam`, `GitHubTeamRepository`; migrations for Postgres/SQLite/SQL Server.
>   - New DB methods: save/list teams, save team-repo links, query teams-for-repo, delete org teams.
>   - New scope `WithTeam` and integration into repository listing.
> - **GitHub Client**:
>   - Add REST helpers to list org teams and team repositories (with pagination and permission mapping).
> - **Frontend**:
>   - Add Team filter to UnifiedFilterSidebar using `OrganizationSelector`; load teams via new API.
>   - Update repository header to reflect team filter; plumb `team` through filters, URL params, types, and API service.
>   - Improve `OrganizationSelector` with portal-based, fixed-position dropdown support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a0d55f5c8ad2f3714793121e6496e4b5687e87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->