### PR TITLE
Update deploy-release workflow to clarify Docker image tag input desc…

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Docker image tag to deploy (e.g., v1.0.0)'
+        description: 'Docker image tag to deploy (e.g., v1.0.0 or 1.0.0)'
         required: true
         type: string
 
@@ -41,6 +41,8 @@ jobs:
           else
             TAG="${{ github.event.inputs.image_tag }}"
           fi
+          # Strip 'v' prefix to match docker/metadata-action semver {{version}} output
+          TAG="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Using image tag: ${TAG}"
 


### PR DESCRIPTION
…ription and strip 'v' prefix from tag. This enhances user guidance and ensures compatibility with docker/metadata-action semver output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow input text and normalizes the release tag string before it’s used for Docker tagging/deploys.
> 
> **Overview**
> Updates the `deploy-release` GitHub Actions workflow to accept image tags with or without a leading `v` and **always strips the `v` prefix** before emitting `steps.get-tag.outputs.tag`.
> 
> This aligns the tag value with `docker/metadata-action` semver `{{version}}` output to avoid mismatched Docker tags during release or manual deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbc631e93615371b9f96d4f410051526c6e40566. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->