### PR TITLE
Increase discovery timeouts for large-scale migrations

### DIFF
--- a/internal/api/handlers/discovery_handlers.go
+++ b/internal/api/handlers/discovery_handlers.go
@@ -143,7 +143,7 @@ func (h *Handler) StartDiscovery(w http.ResponseWriter, r *http.Request) {
 // runDiscoveryAsync executes a discovery operation asynchronously and updates progress
 func (h *Handler) runDiscoveryAsync(progressID int64, tracker *discovery.DBProgressTracker, discoverFn func(context.Context) error, discoveryType, target string, sourceID *int64) {
 	// #nosec G118 -- cancel is called in deferred cleanup; stored in map for external cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), 72*time.Hour)
 
 	// Register cancel function for this discovery
 	h.discoveryMu.Lock()
@@ -355,7 +355,7 @@ func (h *Handler) DiscoverRepositories(w http.ResponseWriter, r *http.Request) {
 	// Start discovery asynchronously with a bounded timeout to prevent goroutine leaks
 	// #nosec G118 -- goroutine intentionally outlives HTTP request; uses its own context with timeout
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 48*time.Hour)
 		defer cancel()
 		if err := collector.DiscoverRepositories(ctx, req.Organization); err != nil {
 			h.logger.Error("Repository discovery failed", "error", err, "org", req.Organization)
@@ -546,7 +546,7 @@ func (h *Handler) startDynamicADOOrgDiscovery(w http.ResponseWriter, req *StartA
 // runDynamicADOOrgDiscovery executes org discovery in background
 func (h *Handler) runDynamicADOOrgDiscovery(organization string, sourceID, progressID int64, collector *discovery.ADOCollector, tracker *discovery.DBProgressTracker) {
 	// #nosec G118 -- cancel is called in deferred cleanup; stored in map for external cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), 72*time.Hour)
 
 	// Register cancel function for this discovery
 	h.discoveryMu.Lock()
@@ -619,7 +619,7 @@ func (h *Handler) startDynamicADOProjectDiscovery(w http.ResponseWriter, req *St
 // runDynamicADOProjectDiscovery executes project discovery in background
 func (h *Handler) runDynamicADOProjectDiscovery(organization string, projects []string, sourceID, progressID int64, collector *discovery.ADOCollector, tracker *discovery.DBProgressTracker) {
 	// #nosec G118 -- cancel is called in deferred cleanup; stored in map for external cancellation
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	ctx, cancel := context.WithTimeout(context.Background(), 72*time.Hour)
 
 	// Register cancel function for this discovery
 	h.discoveryMu.Lock()

--- a/internal/mcp/handlers_discovery.go
+++ b/internal/mcp/handlers_discovery.go
@@ -288,9 +288,9 @@ func (s *Server) handleStartDiscovery(ctx context.Context, req mcp.CallToolReque
 	progressTracker := discovery.NewDBProgressTracker(s.db, s.logger, progress)
 	collector.SetProgressTracker(progressTracker)
 
-	// Launch discovery goroutine with 2-hour timeout
+	// Launch discovery goroutine with 72-hour timeout
 	// #nosec G118 -- cancel is called in the goroutine's deferred cleanup
-	discoveryCtx, cancel := context.WithTimeout(context.Background(), 2*time.Hour)
+	discoveryCtx, cancel := context.WithTimeout(context.Background(), 72*time.Hour)
 
 	// Register cancel function
 	s.discoveryMu.Lock()


### PR DESCRIPTION
## Summary
- Increase full org/enterprise discovery timeout from 2 hours to 72 hours
- Increase repository-only discovery timeout from 30 minutes to 48 hours
- Applies to both API handlers and MCP handler discovery paths

## Test plan
- [ ] Verify discovery operations start and run without premature timeout
- [ ] Verify cancel discovery still works correctly
- [ ] Confirm no regression in discovery progress tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)