### PR TITLE
Add Fishhawk workflow spec (medium autonomy preset)

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -1,0 +1,217 @@
+# Medium-autonomy workflow preset.
+#
+# Canonical, schema-valid workflow-v2 document seeding `fishhawk init`
+# and the App-PR onboarding path. This is the DEFAULT tier: the agent
+# implements; the human approves the plan and the PR; the operator agent
+# is delegated approve, fixup and retry under their named conditions
+# while waive and merge stay human.
+#
+# The three presets are ONE shared base plus a single `autonomy:` line.
+# They stay standalone documents on purpose — see
+# docs/spec/workflow-preset.md for that rationale, the per-tier delta
+# table, and the budget derivation.
+
+version: "2"
+
+workflows:
+
+  # The agent implements; the human approves the plan and the PR. The
+  # `autonomy:` line below is the ONLY difference between the three
+  # shipped presets.
+  feature_change:
+    description: >-
+      Default workflow for feature work and non-trivial changes.
+      Human approves plan and PR; agent does the implementation.
+    # Auto-advance mode: fishhawkd advances the run's mechanical
+    # transitions (review settlement, fixup re-park, derived
+    # awaiting_merge) and surfaces next_action; judgment points still
+    # park for the human.
+    auto_advance: true
+    # Operator-agent delegation tier. `low` delegates nothing — every
+    # judgment point pages the human. `medium` delegates approve, fixup
+    # and retry under their named conditions. `high` adds waive and
+    # merge. An explicit `actions:` entry overrides the tier for that
+    # action class only.
+    autonomy: medium
+    policy:
+      max_stage_runtime: "30m"
+    # Periodic cost ceiling. Advisory — emits a budget_alert audit entry
+    # + originating-issue comment at warn_at (80%) and the 100%
+    # crossing; never blocks a run.
+    budgets:
+      - period: weekly
+        limit_usd: 50
+        warn_at: 0.8
+        enforcement: advisory
+    # Auto-retry once on CI failure. The human approves the plan; the
+    # agent should self-heal on a routine test or lint regression
+    # without forcing the reviewer back into the loop.
+    on_ci_failure:
+      max_retries: 1
+
+    # --- Optional control-surface starters (commented; adapt then uncomment) ---
+    #
+    # applies_to declares which changes this workflow may be used for. A
+    # run whose change does not match is refused before any work begins.
+    # `labels` and `trigger` are checked at run admission; `paths` is
+    # checked at the plan gate, so a `paths` rule is REFUSED at validation on
+    # a workflow that declares no plan stage — it could never be evaluated. To
+    # confine by path, keep a plan stage; otherwise route on `labels` /
+    # `trigger` (checked on every workflow whatever its shape), or use the
+    # stage's `constraints.allowed_paths` (post-hoc, against the produced
+    # diff). Uncomment and adapt:
+    # fishhawk:starter-begin applies_to
+    # applies_to:
+    #   labels: ["type:chore"]
+    #   paths: ["docs/**"]
+    # fishhawk:starter-end applies_to
+    #
+    # escalations raise the bar for a matching change — a higher approval
+    # count, an added membership group, a stricter permission, a lower
+    # autonomy ceiling. An escalation may only ever raise, never lower; one
+    # that would change nothing is refused. A `match.paths` rule is likewise
+    # REFUSED at validation on a workflow that declares no plan stage — it is
+    # checked against the approved plan's scope.files, so it could never fire;
+    # keep a plan stage to escalate by path, or match on `labels` / `trigger`,
+    # checked at run admission on every workflow whatever its shape. Uncomment
+    # and adapt:
+    # fishhawk:starter-begin escalations
+    # escalations:
+    #   - match:
+    #       paths: ["infra/**"]
+    #     require:
+    #       approvals:
+    #         count: 2
+    # fishhawk:starter-end escalations
+
+    stages:
+      - id: plan
+        type: plan
+        # Coding-agent executor, declared per stage rather than hoisted
+        # into a file-level `defaults` block: a governance document is
+        # also read by tooling that does not resolve same-document reuse
+        # (a bare check-jsonschema run), and such a reader must see an
+        # executor on every stage.
+        executor:
+          agent: claude-code
+          # Optionally pin the coding-agent CLI versions these stages were
+          # validated against: a resolved CLI outside the range fails the
+          # stage loudly pre-spawn. The binary pin itself stays a host
+          # concern (FISHHAWK_AGENT_BIN / FISHHAWK_CODEX_BIN); absent = no
+          # constraint. Uncomment and adjust to enforce.
+          # agent_version: ">=2.1 <2.2"
+        # Advisory plan review: agent reviewers surface verdicts before
+        # the human gate. Heterogeneous topology — Claude and Codex
+        # review concurrently. `reviewers` stays per stage for a second
+        # reason: it is taken WHOLE from exactly one rung, so a file-level
+        # block would be inherited by the review stage, which declares
+        # none on purpose.
+        reviewers:
+          # Explicit review authority: makes visible what `agents` +
+          # `human: 1` already resolve to — advisory, so agent verdicts
+          # surface but the human gate decides. An explicit `authority`
+          # wins over the reviewer counts.
+          authority: advisory
+          agents:
+            - provider: claudecode
+              model: claude-opus-4-8
+            - provider: codex
+              model: gpt-5.5
+              # A codex reviewer may likewise pin the reviewer CLI
+              # versions it was validated against: an out-of-range CLI
+              # fails the review dispatch; an unprobeable version
+              # degrades to a warning.
+              # agent_version: ">=2.1 <2.2"
+          human: 1
+        inputs:
+          - source: github_issue
+            required: true
+        produces:
+          - artifact: plan
+            schema: standard_v1
+            persistence:
+              - target: originating_issue
+                mode: rendered_comment
+                update_on_change: true
+              - target: fishhawk_audit_log
+                mode: canonical
+        budget:
+          max_tokens: 200000
+          max_runtime: 15m
+          limit_usd: 4
+          enforcement: advisory
+        gates:
+          # Forge-neutral approval predicate: one approval, excluding the
+          # change's author and any agent identity. No repo-specific
+          # handle to fill in.
+          - type: approval
+            approvals:
+              count: 1
+              not: [author, agent]
+
+      - id: implement
+        type: implement
+        executor:
+          agent: claude-code
+          # Execution-grounded verifier: after the agent exits, run the
+          # project test command against the committed scope-only tree;
+          # on a test failure, feed the captured output back for a
+          # bounded fix loop, then re-verify, before the PR opens.
+          verify:
+            # Backend (go test) + frontend (vitest) suites — see the
+            # `test-all` target in this repo's Makefile.
+            command: "make test-all"
+            timeout: "15m"
+            max_iterations: 1
+        # Advisory implement-review: agent reviewers read the diff
+        # against the approved plan and surface verdicts (incl. the
+        # scope-drift flag). Same Claude+Codex pair as the plan stage,
+        # and declared per stage for the same reason.
+        reviewers:
+          # Explicit review authority: makes visible what `agents` +
+          # `human: 1` already resolve to — advisory, so agent verdicts
+          # surface but the human gate decides. An explicit `authority`
+          # wins over the reviewer counts.
+          authority: advisory
+          agents:
+            - provider: claudecode
+              model: claude-opus-4-8
+            - provider: codex
+              model: gpt-5.5
+          human: 1
+        inputs:
+          - artifact: plan
+            from_stage: plan
+        produces:
+          - artifact: pull_request
+        constraints:
+          max_files_changed: 45
+          forbidden_paths:
+            - ".github/workflows/**"
+            - ".fishhawk/**"
+            - "LICENSE"
+            - "NOTICE"
+          required_outcomes:
+            - tests_added_or_updated
+            - ci_green
+        budget:
+          max_tokens: 500000
+          max_runtime: 30m
+          limit_usd: 12
+          enforcement: advisory
+
+      - id: review
+        type: review
+        executor:
+          human: true
+        inputs:
+          - artifact: pull_request
+            from_stage: implement
+        gates:
+          # Forge-neutral approval predicate: one approval, excluding the
+          # change's author and any agent identity. No repo-specific
+          # handle to fill in.
+          - type: approval
+            approvals:
+              count: 1
+              not: [author, agent]


### PR DESCRIPTION
Onboards this repo to Fishhawk by committing `.fishhawk/workflows.yaml`. The spec only takes effect once it is on the default branch — the readiness check reads the committed file, not a working tree.

## What this configures

A single `feature_change` workflow at the **medium** autonomy tier (the recommended default):

- **plan** — agent writes the plan; advisory Claude + Codex reviewers; one human approval gate (author and agent identities excluded).
- **implement** — agent executes the approved plan, then an execution-grounded verifier runs the test suite before the PR opens; same advisory reviewer pair against the diff.
- **review** — human approval gate on the PR.

Plus: auto-advance for mechanical transitions, one auto-retry on CI failure, and a $50/week advisory budget. Delegated to the operator agent: approve, fixup, retry. Still human: waive and merge.

## Deviation from the stock preset

The implement stage's verifier command is `make test-all` (Go + frontend suites) rather than the preset's placeholder `make test`, which is backend-only in this repo.

## Before merging

The reviewer models (`claude-opus-4-8`, `gpt-5.5`) are the preset defaults. Re-running the Fishhawk readiness check after this lands will report whether this deployment can actually resolve them — the reviewer list comes back empty until the spec is on `main`.

Prior readiness state: GitHub App installed (installation 130008505), token scopes adequate, no spec present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)