### PR TITLE
Fix Fishhawk implement verifier to download embedded binaries

### DIFF
--- a/.fishhawk/workflows.yaml
+++ b/.fishhawk/workflows.yaml
@@ -158,9 +158,18 @@ workflows:
           # on a test failure, feed the captured output back for a
           # bounded fix loop, then re-verify, before the PR opens.
           verify:
-            # Backend (go test) + frontend (vitest) suites — see the
-            # `test-all` target in this repo's Makefile.
-            command: "make test-all"
+            # Backend suite. `download-binaries` is NOT optional: several
+            # packages reach internal/embedded, whose //go:embed
+            # bin/git-sizer-* directives fail the BUILD outright when the
+            # binaries are absent — and they are gitignored, so a fresh
+            # checkout (every implement worktree) never has them. This
+            # mirrors ci.yml, which downloads them before `go test` for
+            # the same reason.
+            #
+            # Backend only: the web suite needs `npm ci` first, which is
+            # too slow to provision per worktree inside this timeout. The
+            # frontend slice runs `npm run test:run` itself.
+            command: "make download-binaries && make test"
             timeout: "15m"
             max_iterations: 1
         # Advisory implement-review: agent reviewers read the diff


### PR DESCRIPTION
The implement stage's verify command was `make test-all`. It cannot build.

Several packages reach `internal/embedded`, whose `//go:embed bin/git-sizer-*` directives fail the **build** — not the tests — when the binaries are absent. Those binaries are gitignored (`.gitignore:12`), so every fresh implement worktree lacks them, and only `make build` depends on `download-binaries`; `make test` does not.

Both children of the first decomposed run on #172 failed category-A on this before a single line of their generated code was evaluated:

```
internal/embedded/binaries.go:28:12: pattern bin/git-sizer-darwin-amd64: no matching files found
FAIL github.com/kuhlman-labs/github-migrator/cmd/server [setup failed]
```

This is not worktree-specific — `go build ./internal/embedded/` fails the same way in a plain checkout that has never run `make setup`.

## Fix

Mirror `.github/workflows/ci.yml`, which has a dedicated *"Download git-sizer binaries (required for embed directives)"* step (line 37) before `go test` (line 72) for exactly this reason:

```yaml
command: "make download-binaries && make test"
```

**Backend only, deliberately.** The web suite needs `npm ci` first, and provisioning that in five concurrent worktrees does not reliably fit the 15m verify timeout. CI runs the frontend as a separate job; the frontend slice runs `npm run test:run` itself.

## Verification

`make download-binaries && make test` exits 0 locally with a clean suite.

## Unrelated observation

`scripts/download-git-sizer.sh` produced a **0-byte** `git-sizer-linux-arm64` while every other target came down at ~3.5MB. The script has `set -e` but the failure was swallowed. Harmless for the embed (the pattern matches an existing file), but that binary would be broken at runtime on linux/arm64. Worth a separate issue — not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)